### PR TITLE
Add release guide and update Docker publish workflow 

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,7 @@ name: Docker Build and Release
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-    types: [ closed ]
+    branches: [main]
 
 env:
   REGISTRY: docker.io
@@ -13,17 +10,64 @@ env:
 
 jobs:
   build-and-release:
-    if: (github.event.pull_request.merged == true || github.ref == 'refs/heads/main') && contains(github.event.head_commit.message, '[release]')
+    if: contains(github.event.pull_request.title, '[release]') || contains(github.event.head_commit.message, '[release]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
+
     outputs:
-      new-version: ${{ steps.get-version.outputs.new-version }}
+      new-version: ${{ steps.bump.outputs.new_version }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout code and tags
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Fetch latest tag from Docker Hub
+        id: get_tag
+        run: |
+          LATEST=$(curl -s "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/?page_size=100" \
+            | jq -r '.results[].name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)
+          if [[ -z "$LATEST" ]]; then
+            echo "LATEST=v0.0.0" >> $GITHUB_ENV
+          else
+            echo "LATEST=$LATEST" >> $GITHUB_ENV
+          fi
+
+      - name: Determine bump level based on commit/PR title
+        id: detect
+        run: |
+          MSG="${{ github.event_name == 'pull_request' && github.event.pull_request.title || github.event.head_commit.message }}"
+          if [[ "$MSG" =~ \[major\] ]]; then echo "LEVEL=major"; \
+          elif [[ "$MSG" =~ \[minor\] ]]; then echo "LEVEL=minor"; \
+          else echo "LEVEL=patch"; fi >> $GITHUB_ENV
+
+      - name: Bump semantic version
+        id: bump
+        uses: actions-ecosystem/action-bump-semver@v1
+        with:
+          current_version: ${{ env.LATEST }}
+          level: ${{ env.LEVEL }}
+
+      - name: Output the new version
+        run: echo "Bumped from ${{ env.LATEST }} → ${{ steps.bump.outputs.new_version }}"
+
+      - name: Checkout with full history for tagging
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Tag the release
+        run: git tag ${{ steps.bump.outputs.new_version }}
+
+      - name: Push the tag
+        run: git push origin refs/tags/${{ steps.bump.outputs.new_version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -35,167 +79,39 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Get latest version from Docker Hub
-        id: get-version
-        run: |
-          # Get latest version from Docker Hub API
-          LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/?page_size=100" | jq -r '.results[].name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
-          
-          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
-            # If no version found, start with v1.0.0
-            LATEST_TAG="v1.0.0"
-            echo "No previous version found, starting with v1.0.0"
-          fi
-          
-          echo "Latest version: $LATEST_TAG"
-          
-          # Extract version parts
-          VERSION_WITHOUT_V=$(echo $LATEST_TAG | sed 's/^v//')
-          IFS='.' read -r major minor patch <<< "$VERSION_WITHOUT_V"
-          
-          # Increment patch version
-          NEW_PATCH=$((patch + 1))
-          NEW_VERSION="v$major.$minor.$NEW_PATCH"
-          
-          # Check if [preview] tag exists in commit message
-          if [[ "${{ github.event.head_commit.message }}" == *"[preview]"* ]]; then
-            NEW_VERSION="$NEW_VERSION-preview"
-            echo "Preview version detected"
-          fi
-          
-          echo "New version: $NEW_VERSION"
-          echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "version-number=$(echo $NEW_VERSION | sed 's/^v//')" >> $GITHUB_OUTPUT
-
-      - name: Generate Docker tags
-        id: meta
-        run: |
-          NEW_VERSION="${{ steps.get-version.outputs.new-version }}"
-          VERSION_NUMBER="${{ steps.get-version.outputs.version-number }}"
-          
-          # Base tags
-          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$NEW_VERSION"
-          
-          # Add additional tags for stable releases (not preview)
-          if [[ "$NEW_VERSION" != *"-preview"* ]]; then
-            IFS='.' read -r major minor patch <<< "$VERSION_NUMBER"
-            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v$major.$minor"
-            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v$major"
-            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          else
-            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:preview"
-          fi
-          
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "Generated tags: $TAGS"
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.bump.outputs.new_version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: |
             org.opencontainers.image.title=Qutora Document Management System
-            org.opencontainers.image.description=Enterprise document management system with multi-database support
-            org.opencontainers.image.version=${{ steps.get-version.outputs.new-version }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.version=${{ steps.bump.outputs.new_version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=MIT
           build-args: |
-            VERSION=${{ steps.get-version.outputs.new-version }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-            VCS_REF=${{ github.sha }}
+            VERSION=${{ steps.bump.outputs.new_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Test Docker image
-        run: |
-          # Use the main version tag for testing
-          TEST_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.new-version }}"
-          
-          docker run --rm -d \
-            --name qutora-test \
-            -p 8080:8080 \
-            -e Database__Provider=SqlServer \
-            -e ConnectionStrings__DefaultConnection="Data Source=test.db" \
-            -e Jwt__Key="test_jwt_secret_key_32_characters_minimum_length_required" \
-            "$TEST_TAG"
-          
-          echo "Waiting for container to start..."
-          sleep 20
-          
-          # Test health endpoint
-          echo "Testing health endpoint..."
-          if curl -f http://localhost:8080/health; then
-            echo "✅ Health check passed!"
-          else
-            echo "⚠️ Health check failed (expected without real database)"
-          fi
-          
-          docker stop qutora-test
-          echo "✅ Docker image test completed"
-
       - name: Create GitHub Release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/create-release@v1
         with:
-          tag_name: ${{ steps.get-version.outputs.new-version }}
-          release_name: Release ${{ steps.get-version.outputs.new-version }}
+          tag_name: ${{ steps.bump.outputs.new_version }}
+          release_name: "Release ${{ steps.bump.outputs.new_version }}"
           body: |
-            ## Qutora Document Management System ${{ steps.get-version.outputs.new-version }}
-            
-            🐳 **Docker Image**: `docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.new-version }}`
-            
-            ### 🚀 Quick Start
-            ```bash
-            docker run -d \
-              --name qutora-api \
-              -p 8080:8080 \
-              -e Database__Provider=SqlServer \
-              -e ConnectionStrings__DefaultConnection="your-connection-string" \
-              -e Jwt__Key="your-jwt-secret-key" \
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.new-version }}
-            ```
-            
-            ### 📋 What's New
-            - Automated release triggered by [release] tag
-            - See commit history for detailed changes: [Compare with previous version](https://github.com/${{ github.repository }}/compare/main)
-            
-            ### 🛠️ Build Information
-            - **Build Date**: ${{ github.event.head_commit.timestamp }}
-            - **Git Commit**: ${{ github.sha }}
-            - **Workflow Run**: [${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          draft: false
-          prerelease: ${{ contains(steps.get-version.outputs.new-version, 'preview') }}
+            ## Qutora API ${{ steps.bump.outputs.new_version }}
+            🚀 Docker image: `docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.bump.outputs.new_version }}`
 
   skip-notification:
-    if: (github.event.pull_request.merged == true || github.ref == 'refs/heads/main') && !contains(github.event.head_commit.message, '[release]')
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[release]')
     runs-on: ubuntu-latest
     steps:
-      - name: Skip Release Notification
-        run: |
-          echo "⏭️ Skipping Docker release - no [release] tag found in commit message"
-          echo "💡 To trigger a release, include [release] in your commit message"
-          echo "💡 To create a preview release, include both [release] and [preview] tags"
-
-  security-scan:
-    runs-on: ubuntu-latest
-    needs: build-and-release
-    if: success()
-    
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-release.outputs.new-version }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif' 
+      - name: No release detected
+        run: echo "⏭️ No [release] tag found, skipping build-and-release."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,65 @@
+# 🚀 Release Guide
+
+This project uses an automated GitHub Actions workflow to build and publish Docker images using **semantic versioning**.
+
+## 🔧 How It Works
+
+- Triggered on pushes to the `main` branch.
+- Requires `[release]` in the commit message or pull request title.
+- Version bump is based on tags in the message (default is patch).
+
+## 🔼 Version Bump Keywords
+
+| Keyword       | Bump Type | Example Version Change |
+|---------------|-----------|------------------------|
+| `[major]`     | Major     | `v1.2.3` → `v2.0.0`     |
+| `[minor]`     | Minor     | `v1.2.3` → `v1.3.0`     |
+| _(default)_   | Patch     | `v1.2.3` → `v1.2.4`     |
+
+If no keyword is given, a patch version is created.
+
+## ✅ Release Examples
+
+### Patch release:
+```bash
+git commit -m "[release] Fix typo in logs"
+```
+
+### Minor release:
+```bash
+git commit -m "[release][minor] Add search endpoint"
+```
+
+### Major release:
+```bash
+git commit -m "[release][major] Replace authentication method"
+```
+
+Then push to main:
+```bash
+git push origin main
+```
+
+## 📦 What It Does
+
+When triggered:
+
+- Detects the latest version from Docker Hub.
+- Bumps the version (semver).
+- Tags the Git commit.
+- Builds and pushes Docker images:
+  - `docker.io/qutora/qutora-api:<version>`
+  - `docker.io/qutora/qutora-api:latest`
+- Creates a GitHub release with notes.
+
+## 🔐 Required Secrets
+
+Set these secrets in your GitHub repository:
+
+- `DOCKER_USERNAME`
+- `DOCKER_PASSWORD`
+
+## ⏭️ Skipped Builds
+
+If `[release]` is not in the commit or PR title, the workflow is skipped.
+


### PR DESCRIPTION
# Initial Release v1.0.0

This PR establishes the foundation for our automated release workflow and marks the first official release of the Qutora API.

## 📋 What's Included

- Initial project setup and core functionality
- Automated GitHub Actions release workflow
- Docker image publishing pipeline
- Semantic versioning implementation

## 🚀 Release Process

To trigger the release, this PR should be merged with the following commit message format:

```
[release][major]
```

## 🎯 Expected Outcome

Upon merge with the `[release][major]` tags:

- Version will be bumped to v1.0.0
- Docker images will be built and pushed to `docker.io/qutora/qutora-api:v1.0.0`
- GitHub release will be created with release notes
- Git tag v1.0.0 will be applied

## 📦 Docker Images

The release will create:

- `docker.io/qutora/qutora-api:v1.0.0`
- `docker.io/qutora/qutora-api:latest`

## ⚠️ Important Notes

- Ensure `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are configured in GitHub
- This is a major version bump as it's the initial release
- Future releases can use `[minor]` or `[patch]` keywords for smaller version increments

---

**Ready for initial release! 🎉**